### PR TITLE
Dcussans/macprom

### DIFF
--- a/boards/afc/synth/firmware/cfg/afc_infra.dep
+++ b/boards/afc/synth/firmware/cfg/afc_infra.dep
@@ -25,8 +25,18 @@
 
 
 src afc_infra.vhd
+
+# The output of the compilation of the C running on the NEO.
+# To rebuild, use gcc-msp430 and the s/ware in the s/ware sub directory
+src -c enclustra:components/neo430_wrapper neo430_application_image_macprom.vhd
+
+include -c enclustra:components/neo430_wrapper neo430_wrapper.dep
+
 src -c ipbus-firmware:components/ipbus_util clocks/clocks_7s_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
 src -c ipbus-firmware:components/ipbus_util masters/ipbus_ctrl.vhd
 include -c ipbus-firmware:components/ipbus_transport_udp
 include -c ipbus-firmware:components/ipbus_eth artix_basex.dep
 src -c ipbus-firmware:components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd
+
+# Pull in TCL that will put neo430_package etc. into neo430, not work.
+setup  -c enclustra:components/neo430_wrapper -f ../cfg/neo430_macprom.tcl

--- a/boards/afc/synth/firmware/hdl/afc_infra.vhd
+++ b/boards/afc/synth/firmware/hdl/afc_infra.vhd
@@ -36,6 +36,14 @@ use IEEE.STD_LOGIC_1164.ALL;
 use work.ipbus.all;
 
 entity afc_infra is
+ 	generic (
+          CLK_AUX_FREQ : real := 40.0 ; -- Default: 40 MHz clock - LHC
+          USE_NEO430 : boolean := False; -- Set to "true" in order to include
+                                         -- NEO430 soft-core to read MAC/IP
+          NEO430_CLOCK_SPEED : natural := 31250000 ; -- soft core clock speed
+          FORCE_RARP : boolean := False; -- Set True in order to force use of RARP, regardless of PROM
+          UID_I2C_ADDR : std_logic_vector(7 downto 0) := x"53" -- Address on I2C bus of E24AA025E
+		); 
 	port(
 		eth_clk_p: in std_logic; -- 125MHz MGT clock
 		eth_clk_n: in std_logic;
@@ -51,8 +59,21 @@ entity afc_infra is
 		nuke: in std_logic; -- The signal of doom
 		soft_rst: in std_logic; -- The signal of lesser doom
 		leds: out std_logic_vector(1 downto 0); -- status LEDs
-		mac_addr: in std_logic_vector(47 downto 0); -- MAC address
-		ip_addr: in std_logic_vector(31 downto 0); -- IP address
+
+                -- Communication to soft core CPU reading MAC/IP
+                uart_txd_o : out std_logic; -- UART connection between soft core and serial terminal
+		uart_rxd_i : in std_logic :='0' ;
+
+                -- I2C bus to PROM holding MAC (and possibly IP)
+		uid_scl_o: out std_logic; -- I2C bus connected to EEPROM storing MAC address and (if desired IP address)
+		uid_sda_o: out std_logic;
+		uid_scl_i: in std_logic :='0' ; 
+		uid_sda_i: in std_logic :='0' ; 
+
+                -- MAC/IP address if using fixed MAC/IP
+		mac_addr: in std_logic_vector(47 downto 0) := (others =>'0'); -- MAC address
+		ip_addr: in std_logic_vector(31 downto 0) := (others =>'0'); -- IP address
+                
 		ipb_in: in ipb_rbus; -- ipbus
 		ipb_out: out ipb_wbus
 	);
@@ -61,11 +82,39 @@ end afc_infra;
 
 architecture rtl of afc_infra is
 
+      -- Can't use direct instantiation ( entity work.ipbus_neo430_wrapper ) since if USE_NEO430 is False, then don't want to have to include ipbus_neo430_wrapper.vhd
+  COMPONENT ipbus_neo430_wrapper IS
+    GENERIC( 
+        CLOCK_SPEED : natural := 31250000;
+        UID_I2C_ADDR : std_logic_vector(7 downto 0) := x"53" -- Address on I2C bus of E24AA025E
+        );
+    PORT( 
+        clk_i      : IN     std_logic;                      -- global clock, rising edge
+        rst_i      : IN     std_logic;                      -- global reset, async, active high
+        uart_txd_o : OUT    std_logic;                      -- UART from NEO to host
+        uart_rxd_i : IN     std_logic;                      -- from host to NEO UART
+        leds       : OUT    std_logic_vector (3 DOWNTO 0);  -- status LEDs
+        scl_o      : OUT    std_logic;                      -- I2C clock from NEO
+        scl_i      : IN     std_logic;                      -- the actual state of the line back to NEO
+        sda_o      : OUT    std_logic;                      -- I2C data from NEO
+        sda_i      : IN     std_logic;
+        gp_o       : OUT    std_logic_vector(11 downto 0);  -- General purpose output. Used in DUNE to define the endpoint ID
+        use_rarp_o : OUT    std_logic;                      -- If high then IPBus should use RARP, not fixed IP
+        ip_addr_o  : OUT    std_logic_vector(31 downto 0);  -- IP address to give to IPBus core
+        mac_addr_o : OUT    std_logic_vector(47 downto 0);  -- MAC address to give to IPBus core
+        ipbus_rst_o: OUT    std_logic                       -- Reset line to IPBus core
+        );
+    end component;
+
 	signal clk125_fr, clk125, clk_ipb, clk_ipb_i, locked, clk_locked, eth_locked, rst125, rst_ipb, rst_ipb_ctrl, rst_eth, onehz, pkt: std_logic;
 	signal mac_tx_data, mac_rx_data: std_logic_vector(7 downto 0);
 	signal mac_tx_valid, mac_tx_last, mac_tx_error, mac_tx_ready, mac_rx_valid, mac_rx_last, mac_rx_error: std_logic;
 	signal led_p: std_logic_vector(0 downto 0);
-	
+	signal s_mac_addr, s_neo430_mac_addr: std_logic_vector(47 downto 0); -- MAC address
+	signal s_ip_addr , s_neo430_ip_addr:  std_logic_vector(31 downto 0); -- IP address
+	signal internal_nuke, neo430_nuke: std_logic := '0';
+        signal neo430_RARP_select , RARP_select : std_logic := '0'; -- set high to use RARP
+    	
 begin
 
 --	DCM clock generation for internal bus, ethernet
@@ -78,7 +127,7 @@ begin
 			clko_200 => clk200,
 			eth_locked => eth_locked,
 			locked => clk_locked,
-			nuke => nuke,
+			nuke => internal_nuke,
 			soft_rst => soft_rst,
 			rsto_125 => rst125,
 			rsto_ipb => rst_ipb,
@@ -106,7 +155,35 @@ begin
 		);
 
 	leds <= (led_p(0), locked and onehz);
-		
+
+    -- Soft core to read MAC and IP address
+    gen_softcore: if USE_NEO430 generate
+	soft_core_cpu: ipbus_neo430_wrapper
+		generic map(
+                  CLOCK_SPEED =>  NEO430_CLOCK_SPEED, -- 31.25MHz IPBus clock
+                  UID_I2C_ADDR => UID_I2C_ADDR 
+                  )
+		port map(
+			clk_i => clk_ipb,	-- global clock, rising edge
+			rst_i => '0',		-- CPU reset. Active high. Async
+			uart_txd_o => uart_txd_o,-- UART from NEO to host
+      		uart_rxd_i => uart_rxd_i,-- from host to NEO UART
+      		leds       => open, -- status LEDs
+	    	scl_o      => uid_scl_o,                      -- I2C clock from NEO
+	    	scl_i      => uid_scl_i,                       -- the actual state of the line back to NEO
+    		sda_o      => uid_sda_o,                        -- I2C data from NEO
+    		sda_i      => uid_sda_i,
+    		use_rarp_o => neo430_RARP_select,
+    		gp_o       => gp_o,
+    		ip_addr_o  => s_neo430_ip_addr,
+    		mac_addr_o => s_neo430_mac_addr,
+    		ipbus_rst_o => neo430_nuke
+			);
+    end generate gen_softcore;
+
+        -- combine resets
+	internal_nuke <= nuke or neo430_nuke;
+        
 -- Ethernet MAC core and PHY interface
 	
 	eth: entity work.eth_7s_1000basex_gtp
@@ -152,9 +229,17 @@ begin
 			mac_tx_ready => mac_tx_ready,
 			ipb_out => ipb_out,
 			ipb_in => ipb_in,
-			mac_addr => mac_addr,
-			ip_addr => ip_addr,
+                        RARP_select => RARP_select,
+			mac_addr => s_mac_addr,
+			ip_addr => s_ip_addr,
 			pkt => pkt
 		);
 
+        -- If we are using the NEO430 soft core, get the MAC,IP addresses from there
+        -- Otherwise use the input ports.
+        s_mac_addr <= s_neo430_mac_addr when USE_NEO430 else mac_addr;
+        s_ip_addr  <= s_neo430_ip_addr  when USE_NEO430 else ip_addr;
+    
+        RARP_select <= '1' when (neo430_RARP_select='1' or FORCE_RARP) else '0';
+ 
 end rtl;

--- a/boards/afc/synth/firmware/hdl/afc_infra.vhd
+++ b/boards/afc/synth/firmware/hdl/afc_infra.vhd
@@ -174,7 +174,7 @@ begin
     		sda_o      => uid_sda_o,                        -- I2C data from NEO
     		sda_i      => uid_sda_i,
     		use_rarp_o => neo430_RARP_select,
-    		gp_o       => gp_o,
+    		gp_o       => open,
     		ip_addr_o  => s_neo430_ip_addr,
     		mac_addr_o => s_neo430_mac_addr,
     		ipbus_rst_o => neo430_nuke

--- a/boards/afc/synth/firmware/ucf/afc.tcl
+++ b/boards/afc/synth/firmware/ucf/afc.tcl
@@ -45,6 +45,19 @@ set_property PACKAGE_PIN AK15 [get_ports eth_rx_n]
 set_property PACKAGE_PIN AL14 [get_ports eth_tx_p]
 set_property PACKAGE_PIN AM14 [get_ports eth_tx_n]
 
+# UART pins (not always used). Unfortunately can either be 2V5 or 3V3. 
+# Depends on what VAUX is set to.
+if { [llength [get_ports {FTDI*}]] > 0} {
+    #if { $FTDI_IO_VOLTAGE == 33} {
+    #    set_property IOSTANDARD LVCMOS33 [get_port {FTDI_*}]
+    #} else {
+    #    set_property IOSTANDARD LVCMOS25 [get_port {FTDI_*}]
+    #}
+    set_property IOSTANDARD LVCMOS25 [get_port {FTDI_*}]
+    set_property PACKAGE_PIN Y11 [get_port {FTDI_RXD}]
+    set_property PACKAGE_PIN AB11 [get_port {FTDI_TXD}]
+}
+
 
 # Clocks derived from system clock
 create_generated_clock -name ipbus_clk -source [get_pins infra/clocks/mmcm/CLKIN1] [get_pins infra/clocks/mmcm/CLKOUT1]


### PR DESCRIPTION
Changed dep files to allow soft core (neo430) to be implemented which sets the MAC (and optionally the IP address)
by reading them from an I2C attached PROM